### PR TITLE
denylist site-packages and dist-packages from deduperreload

### DIFF
--- a/IPython/extensions/deduperreload/deduperreload.py
+++ b/IPython/extensions/deduperreload/deduperreload.py
@@ -119,7 +119,11 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
         """
         for new_modname in sys.modules.keys() - self.source_by_modname.keys():
             new_module = sys.modules[new_modname]
-            if (fname := get_module_file_name(new_module)) is None or "site-packages" in fname:
+            if (
+                (fname := get_module_file_name(new_module)) is None
+                or "site-packages" in fname
+                or "dist-packages" in fname
+            ):
                 self.source_by_modname[new_modname] = ""
                 continue
             with open(fname, "r") as f:

--- a/IPython/extensions/deduperreload/deduperreload.py
+++ b/IPython/extensions/deduperreload/deduperreload.py
@@ -119,15 +119,14 @@ class DeduperReloader(DeduperReloaderPatchingMixin):
         """
         for new_modname in sys.modules.keys() - self.source_by_modname.keys():
             new_module = sys.modules[new_modname]
-            if (fname := get_module_file_name(new_module)) is None:
+            if (fname := get_module_file_name(new_module)) is None or "site-packages" in fname:
                 self.source_by_modname[new_modname] = ""
                 continue
-            if os.access(fname, os.R_OK):
-                with open(fname, "r") as f:
-                    try:
-                        self.source_by_modname[new_modname] = f.read()
-                    except Exception:
-                        self.source_by_modname[new_modname] = ""
+            with open(fname, "r") as f:
+                try:
+                    self.source_by_modname[new_modname] = f.read()
+                except Exception:
+                    self.source_by_modname[new_modname] = ""
 
     @classmethod
     def _gather_children(


### PR DESCRIPTION
See [this comment](https://github.com/ipython/ipython/pull/14500#issuecomment-2395060764), we probably need a way to prevent deduperreload from reading in every imported module. Assume that modules in `site-packages` and `dist-packages` are likely to not be reloaded by the user, so that we can abstain from reading their file contents.